### PR TITLE
Add managed memory example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,10 +33,11 @@ endif()
 find_package(hip REQUIRED)
 
 # HIPFort
-find_package(hipfort REQUIRED)
+#find_package(hipfort REQUIRED)
+
 
 # Set the GPU architecture for the hipfc compiler and enable OpenMP
-set( CMAKE_Fortran_FLAGS "-fPIC -fopenmp" )
+set( CMAKE_Fortran_FLAGS "-v -fPIC" )
 
 if ((DEFINED ENV{HIP_PLATFORM}) AND ($ENV{HIP_PLATFORM} STREQUAL nvidia))
     message("Performing compilation for an NVIDIA backend.")
@@ -62,7 +63,7 @@ if ((DEFINED ENV{HIP_PLATFORM}) AND ($ENV{HIP_PLATFORM} STREQUAL nvidia))
     endforeach()
 
     # Set compiler flags
-    set(CMAKE_CUDA_FLAGS "-g -Xcompiler -fopenmp -Xcompiler -fPIC")
+    set(CMAKE_CUDA_FLAGS "-g -Xcompiler -Xcompiler -fPIC")
     set(CMAKE_CUDA_FLAGS_DEBUG "-G -O0")
     set(CMAKE_CUDA_FLAGS_PROFILE "-pg -O3")
     set(CMAKE_CUDA_FLAGS_RELEASE "-O3")
@@ -73,6 +74,10 @@ if ((DEFINED ENV{HIP_PLATFORM}) AND ($ENV{HIP_PLATFORM} STREQUAL nvidia))
     remove_definitions(-D__HIP_PLATFORM_HCC__ -D__HIP_PLATFORM_AMD__)
     ## Replace it with CUDA precprocessor definitions
     add_definitions(-D__HIP_PLATFORM_NVCC__ -D__HIP_PLATFORM_NVIDIA__)  
+
+    find_library(HIPFORT_LIBRARIES NAMES libhipfort-nvptx.a HINTS ENV HIPFORT_ROOT REQUIRED)
+    find_path(HIPFORT_INCLUDE_DIRS hipfort.mod HINTS ENV HIPFORT_ROOT PATH_SUFFIXES include/hipfort/amdgcn/ REQUIRED)
+
 
 else()
 
@@ -92,10 +97,14 @@ else()
     endforeach()
 
     # Set HIP flags
-    set(CMAKE_HIP_FLAGS "${CMAKE_HIP_FLAGS} -g -fopenmp")
+    set(CMAKE_HIP_FLAGS "${CMAKE_HIP_FLAGS} -g")
     set(CMAKE_HIP_FLAGS_DEBUG, "-ggdb -O1")
     set(CMAKE_HIP_FLAGS_PROFILE, "-pg -O3")
     set(CMAKE_HIP_FLAGS_RELEASE, "-O3")
+
+    find_library(HIPFORT_LIBRARIES NAMES libhipfort-amdgcn.a HINTS ENV HIPFORT_ROOT REQUIRED)
+    find_path(HIPFORT_INCLUDE_DIRS hipfort.mod HINTS ENV HIPFORT_ROOT PATH_SUFFIXES include/hipfort/amdgcn/ REQUIRED)
+
     
 endif()
 

--- a/L5_Hipfort_Examples/CMakeLists.txt
+++ b/L5_Hipfort_Examples/CMakeLists.txt
@@ -59,5 +59,20 @@ set_target_properties(tensoradd_hip_oo
 install(TARGETS tensoradd_hip_oo DESTINATION bin)
 
 
+# tensoradd_hip_fptr_managed - Tensor addition with HIP and Fortran pointers and managed memory
+add_executable (tensoradd_hip_fptr_managed
+    ${CMAKE_CURRENT_SOURCE_DIR}/tensoradd_hip_fptr_managed.f90
+    ${KERNEL_FILES}
+    ${COMMON_FILES}
+)
+# Link in other libraries
+target_link_libraries(tensoradd_hip_fptr_managed ${kernel_libs})
+# This is needed so that the linker used is the Fortran compiler
+set_target_properties(tensoradd_hip_fptr_managed
+    PROPERTIES LINKER_LANGUAGE Fortran
+)                   
+install(TARGETS tensoradd_hip_fptr_managed DESTINATION bin)
+
+
 
 

--- a/L5_Hipfort_Examples/tensoradd_hip_fptr_managed.f90
+++ b/L5_Hipfort_Examples/tensoradd_hip_fptr_managed.f90
@@ -1,0 +1,114 @@
+program tensoradd
+    !! Program to compute 2D tensor addition
+    !! Using Fortran pointers as the handle 
+    !! for device allocations
+    !! Written by Dr. Toby Potter and Dr. Joseph Schoonover
+
+    ! Add this to use the standard Fortran environment module
+    use iso_fortran_env
+
+    ! C interopability 
+    use iso_c_binding
+
+    ! HIP modules
+    use hipfort
+    use hipfort_check
+
+    ! device handling 
+    use hip_utils, only : init_device, reset_device
+
+    ! Maths check
+    use math_utils, only : check => check_tensor_addition_2D
+
+    ! Add this to make sure that all variables must be declared
+    ! and the compiler performs no type inferencing based on the 
+    ! on the first letter of variable names
+    implicit none
+
+    ! Interface to launch_kernel_hip function
+    ! in the file kernel_code.cpp
+    interface
+        ! A C function with void return type
+        ! is regarded as a subroutine in Fortran 
+        subroutine launch_kernel_hip(A, B, C, M, N) bind(C)
+            use iso_c_binding
+            ! Fortran passes arguments by reference as the default
+            ! Arguments must have the "value" option present to pass by value
+            ! Otherwise launch_kernel will receive pointers of type void**
+            ! instead of void*
+            type(c_ptr), intent(in), value :: A, B, C
+            integer(c_int), intent(in), value :: M, N
+        end subroutine
+        
+    end interface
+
+    ! Number of elements in the tensors
+    integer, parameter :: M=14, N=16
+
+    ! Epsilon multiplier
+    ! How many floating point spacings
+    ! should the computed solution be from the answer
+    real :: eps_mult = 2.0
+
+    ! Outcome of the check
+    logical :: success
+
+    ! Fortran pointers to memory allocations on the host
+    real(kind=c_float), dimension(:,:), pointer :: A, B, C
+
+
+    ! Find and set the device. Use device 0 by default
+    call init_device(0)   
+
+    ! Allocate managed memory that is accessible across host and device
+    call hipCheck(hipMallocManaged(A, M, N, hipMemAttachGlobal))
+    call hipCheck(hipMallocManaged(B, M, N, hipMemAttachGlobal))
+    call hipCheck(hipMallocmanaged(C, M, N, hipMemAttachGlobal))
+
+    ! Set coarse grained coherence for all variables
+    call hipCheck(hipMemAdvise(c_loc(A), sizeof(A), hipMemAdviseSetCoarseGrain,0))
+    call hipCheck(hipMemAdvise(c_loc(B), sizeof(B), hipMemAdviseSetCoarseGrain,0))
+    call hipCheck(hipMemAdvise(c_loc(C), sizeof(C), hipMemAdviseSetCoarseGrain,0))
+
+    ! Fill arrays with random numbers using the
+    ! Fortran intrinsic function "random_number"
+    call random_number(A)
+    call random_number(B)
+
+    ! Pre-fetch A and B to the device
+    ! Copy memory from the host to the device
+    ! Note that size for the copy is in elements, not bytes
+    call hipCheck(hipMemPrefetchAsync(c_loc(A),sizeof(A),0,c_null_ptr))
+    call hipCheck(hipMemPrefetchAsync(c_loc(B),sizeof(B),0,c_null_ptr))
+
+    ! Call the C function that launches the kernel
+    call launch_kernel_hip( &
+        c_loc(A), &
+        c_loc(B), &
+        c_loc(C), &
+        int(M, c_int), &
+        int(N, c_int) &
+    )
+
+    ! Block the CPU (host) from progressing until the hip kernel finishes
+    call hipcheck(hipDeviceSynchronize())
+
+    ! Check the answer
+    success = check(A, B, C, eps_mult)
+
+    ! Release resources
+
+    ! Free allocations
+    call hipcheck(hipfree(A))
+    call hipcheck(hipfree(B))
+    call hipcheck(hipfree(C))
+
+    ! It is best practice to nullify all pointers 
+    ! once we are done with them 
+    nullify(A, B, C)
+
+    ! Make sure all resources on the selected device are released
+    call reset_device
+    
+end program tensoradd
+

--- a/env
+++ b/env
@@ -12,6 +12,14 @@ then
 
     export HIP_PLATFORM=amd
     export GPU_ARCH=gfx90a
+elif [[ $HOSTNAME =~ "noether" ]]
+then
+
+    module load gcc/13.2.0 hip/5.7.3 cmake/3.27.9 hipfort/5.7.1
+    export HIP_PLATFORM=amd
+    export GPU_ARCH=gfx90a
+    export HIPFORT_COMPILER=$(which gfortran)
+
 else
     # Load crucial modules
     module load gcc rocm mpich
@@ -46,4 +54,4 @@ export FC=hipfc
 # Set the build type, options are DEBUG, COVERAGE, PROFILE, RELEASE
 export BUILD_TYPE=DEBUG
 
-export HIPFLAGS="-fPIC -fopenmp"
+export HIPFLAGS="-fPIC"


### PR DESCRIPTION
* Removed -fopenmp flag from FFLAGS and HIPFLAGS . To implement openmp+hipfort, we will need to enforce using the amdflang compiler, which supports gpu offloading.. further, hipfort will need to be built using amdflang, which is not the default distribution of hipfort

* Adjusted cmakelists.txt to find static libs and includes directories for hipfort, rather than using find_package(hipfort). This is a bit more portable across v5 and v6 of hipfort, since v5 does not have hipfort-config.cmake.